### PR TITLE
Adding stm32h5 board support

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Build and Push CI Image
         uses: docker/build-push-action@v6
         with:
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           context: .
           file: Dockerfile.ci
           tags: ${{ steps.meta_ci.outputs.tags }}
@@ -112,7 +112,7 @@ jobs:
       - name: Build and Push Dev Image
         uses: docker/build-push-action@v6
         with:
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           context: .
           file: Dockerfile.dev
           tags: ${{ steps.meta_dev.outputs.tags }}

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -18,7 +18,7 @@ ENV ZEPHYR_TOOLCHAIN_VARIANT=zephyr
 ENV ZEPHYR_SDK_VERSION=${ZSDK_VERSION}
 ENV ZEPHYR_SDK=${ZEPHYR_SDK_DIR}/zephyr-sdk-${ZSDK_VERSION}
 ENV ZEPHYR_SDK_INSTALL_DIR=${ZEPHYR_SDK}
-ENV CMAKE_PREFIX_PATH ${ZEPHYR_SDK_DIR}
+ENV CMAKE_PREFIX_PATH=${ZEPHYR_SDK_DIR}
 
 # Install udev and git
 RUN apt-get -y update && \
@@ -48,6 +48,9 @@ RUN chown -R ${USERNAME}:${USERNAME} ${ZEPHYR_SDK}
 # user's home directory.
 USER $USERNAME
 WORKDIR /home/$USERNAME
+
+# Needed for nRF53 Network Core builds
+RUN pip3 install ecdsa
 
 RUN sudo -E -- bash -c ' \
     ${ZEPHYR_SDK}/setup.sh -c && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,9 +7,9 @@ ARG arch=amd64
 
 USER root
 
-# Install udev and git
+# Install udev git and vim
 RUN apt update && \
-    apt -y install screen git curl
+    apt -y install screen git curl vim
 
 # JLink Tools
 RUN <<EOT
@@ -76,14 +76,6 @@ EOT
 # user's home directory.
 USER $USERNAME
 WORKDIR /home/$USERNAME
-
-# Install minimal SVD files
-# https://stackoverflow.com/a/52269934
-# RUN git clone -n --depth=1 --filter=tree:0 https://github.com/cmsis-svd/cmsis-svd-data.git && \
-#     cd cmsis-svd-data && \
-#     git sparse-checkout set --no-cone data/STMicro && \
-#     git checkout
-# ENV SVD_DIR=/home/${USERNAME}/cmsis-svd-data/data/STMicro
 
 # Install STM32 SVD files
 RUN git clone -n --depth=1 https://github.com/modm-io/cmsis-svd-stm32

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE
-FROM ${BASE_IMAGE:-zephyrprojectrtos/ci-base:latest}
+FROM ${BASE_IMAGE:-ghcr.io/mistywest/zephyr-ci:amd64}
 
 ARG JLINK_VERSION=812d
 ARG NORDIC_COMMAND_LINE_TOOLS_VERSION="10-24-2/nrf-command-line-tools-10.24.2"

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -85,6 +85,8 @@ RUN git clone -n --depth=1 --filter=tree:0 https://github.com/cmsis-svd/cmsis-sv
     git checkout
 ENV SVD_DIR=/home/${USERNAME}/cmsis-svd-data/data/STMicro
 
+RUN pyocd pack --update && pyocd pack --install stm32h5
+
 ENV XDG_CACHE_HOME=/home/${USERNAME}/.cache
 ENV PATH="${ZEPHYR_SDK}/sysroots/x86_64-pokysdk-linux/usr/bin:${PATH}"
 ENV PATH="/opt/SEGGER/JLink:${PATH}"

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -79,11 +79,15 @@ WORKDIR /home/$USERNAME
 
 # Install minimal SVD files
 # https://stackoverflow.com/a/52269934
-RUN git clone -n --depth=1 --filter=tree:0 https://github.com/cmsis-svd/cmsis-svd-data.git && \
-    cd cmsis-svd-data && \
-    git sparse-checkout set --no-cone data/STMicro && \
-    git checkout
-ENV SVD_DIR=/home/${USERNAME}/cmsis-svd-data/data/STMicro
+# RUN git clone -n --depth=1 --filter=tree:0 https://github.com/cmsis-svd/cmsis-svd-data.git && \
+#     cd cmsis-svd-data && \
+#     git sparse-checkout set --no-cone data/STMicro && \
+#     git checkout
+# ENV SVD_DIR=/home/${USERNAME}/cmsis-svd-data/data/STMicro
+
+# Install STM32 SVD files
+RUN git clone -n --depth=1 https://github.com/modm-io/cmsis-svd-stm32
+ENV SVD_DIR=/home/${USERNAME}/cmsis-svd-stm32
 
 RUN pyocd pack --update && pyocd pack --install stm32h5
 


### PR DESCRIPTION
**Implements the following changes to add support for the STM32H5 nucleo board and address some issues that came up along the way.**

- STM32H5 is not supported by openocd at this time, so runner changed to pyocd, which required additional target information to be installed (added).

- Docker image built locally had errors as it was unable to locate the defined base image. Fixed this by updating the default base image for the build to point to the GHCR ci image link instead.

- Old repo that was cloned for the SVD files did not contain support for the STM32H5, so a new one was found and updated (example project is being updated to match).

- Added a change to the ci base image that was required for nRF53 Network Core builds, requested by Sid.

- Added vim at Tonys request.

**Testing/Process:**
- Issue with the local build was that it could not find the correct base image so instead built with a default.

- We tested by building the .dev image while specifying the correct base image with docker build -f Dockerfile.dev --build-arg BASE_IMAGE=ghcr.io/mistywest/zephyr-ci:amd64 -t charlie_test .

- This worked, then added Sids pip3 change to the local .ci file then built the .ci image locally, calling it charlie_ci

- Then tried building with this base image and it worked

- Now that we know these changes work fine, we updated the base image specification in the .dev file to point to the correct base image (FROM ${BASE_IMAGE:[-ghcr.io/mistywest/zephyr-ci:amd64](about:blank)})

- Tested docker image build and worked fine, STM32H5 builds,flashes, and debuggs, tested STM32F4 still working as well (didn't break it).

*Tested using the 'adding_nucleo_l4r5zi' branch from 'mw-example-application', which adds STM32H5 board support from the project side.*